### PR TITLE
chore: update dependencies for Filament 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,19 +16,20 @@
         }
     ],
     "require": {
-        "php": "^8.1 || ^8.2 || ^8.3",
+        "php": "^8.2 || ^8.3",
         "archtechx/money": "^0.5.1",
-        "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
-        "laravellegends/pt-br-validator": "^10.0 || ^11.0 || ^12.0",
+        "filament/filament": "^4.0",
+        "illuminate/contracts": "^11.0 || ^12.0",
+        "laravellegends/pt-br-validator": "^11.0 || ^12.0",
+        "livewire/livewire": "^3.0",
         "moneyphp/money": "^4.5",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.9",
-        "larastan/larastan": "^2.9.2",
-        "orchestra/testbench": "^8.0",
+        "nunomaduro/collision": "^8.1",
+        "larastan/larastan": "^3.0",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",


### PR DESCRIPTION
## Summary
- update package to Filament 4 and Livewire 3
- align Laravel-related dependencies for v11+

## Testing
- `composer update` *(fails: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: vendor/bin/pest: not found)*
- `composer analyse` *(fails: vendor/bin/phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb04d320a0832e9a3d892917c18193