### PR TITLE
refactor: update CEP actions for Filament v4

### DIFF
--- a/src/Cep.php
+++ b/src/Cep.php
@@ -37,29 +37,22 @@ class Cep extends TextInput
             ->mask('99999-999')
             ->afterStateUpdated(function ($state, Livewire $livewire, Set $set, Component $component) use ($errorMessage, $setFields, $viaCepRequest) {
                 $viaCepRequest($state, $livewire, $set, $component, $errorMessage, $setFields);
-            })
-            ->suffixAction(function () use ($mode, $errorMessage, $setFields, $viaCepRequest) {
-                if ($mode === 'suffix') {
-                    return Action::make('search-action')
-                        ->label('Buscar CEP')
-                        ->icon('heroicon-o-magnifying-glass')
-                        ->action(function ($state, Livewire $livewire, Set $set, Component $component) use ($errorMessage, $setFields, $viaCepRequest) {
-                            $viaCepRequest($state, $livewire, $set, $component, $errorMessage, $setFields);
-                        })
-                        ->cancelParentActions();
-                }
-            })
-            ->prefixAction(function () use ($mode, $errorMessage, $setFields, $viaCepRequest) {
-                if ($mode === 'prefix') {
-                    return Action::make('search-action')
-                        ->label('Buscar CEP')
-                        ->icon('heroicon-o-magnifying-glass')
-                        ->action(function ($state, Livewire $livewire, Set $set, Component $component) use ($errorMessage, $setFields, $viaCepRequest) {
-                            $viaCepRequest($state, $livewire, $set, $component, $errorMessage, $setFields);
-                        })
-                        ->cancelParentActions();
-                }
             });
+
+        $action = Action::make('search-action')
+            ->label('Buscar CEP')
+            ->icon('heroicon-o-magnifying-glass')
+            ->action(function ($state, Livewire $livewire, Set $set, Component $component) use ($errorMessage, $setFields, $viaCepRequest) {
+                $viaCepRequest($state, $livewire, $set, $component, $errorMessage, $setFields);
+            });
+
+        if ($mode === 'suffix') {
+            $this->suffixActions([$action]);
+        }
+
+        if ($mode === 'prefix') {
+            $this->prefixActions([$action]);
+        }
 
         return $this;
     }

--- a/src/PtbrCep.php
+++ b/src/PtbrCep.php
@@ -40,29 +40,22 @@ class PtbrCep extends TextInput
             ->mask('99999-999')
             ->afterStateUpdated(function ($state, Livewire $livewire, Set $set, Component $component) use ($errorMessage, $setFields, $viaCepRequest) {
                 $viaCepRequest($state, $livewire, $set, $component, $errorMessage, $setFields);
-            })
-            ->suffixAction(function () use ($mode, $errorMessage, $setFields, $viaCepRequest) {
-                if ($mode === 'suffix') {
-                    return Action::make('search-action')
-                        ->label('Buscar CEP')
-                        ->icon('heroicon-o-magnifying-glass')
-                        ->action(function ($state, Livewire $livewire, Set $set, Component $component) use ($errorMessage, $setFields, $viaCepRequest) {
-                            $viaCepRequest($state, $livewire, $set, $component, $errorMessage, $setFields);
-                        })
-                        ->cancelParentActions();
-                }
-            })
-            ->prefixAction(function () use ($mode, $errorMessage, $setFields, $viaCepRequest) {
-                if ($mode === 'prefix') {
-                    return Action::make('search-action')
-                        ->label('Buscar CEP')
-                        ->icon('heroicon-o-magnifying-glass')
-                        ->action(function ($state, Livewire $livewire, Set $set, Component $component) use ($errorMessage, $setFields, $viaCepRequest) {
-                            $viaCepRequest($state, $livewire, $set, $component, $errorMessage, $setFields);
-                        })
-                        ->cancelParentActions();
-                }
             });
+
+        $action = Action::make('search-action')
+            ->label('Buscar CEP')
+            ->icon('heroicon-o-magnifying-glass')
+            ->action(function ($state, Livewire $livewire, Set $set, Component $component) use ($errorMessage, $setFields, $viaCepRequest) {
+                $viaCepRequest($state, $livewire, $set, $component, $errorMessage, $setFields);
+            });
+
+        if ($mode === 'suffix') {
+            $this->suffixActions([$action]);
+        }
+
+        if ($mode === 'prefix') {
+            $this->prefixActions([$action]);
+        }
 
         return $this;
     }


### PR DESCRIPTION
## Summary
- refactor CEP input action handling to new Filament API
- mirror updates in deprecated PtbrCep component

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0757bdfc832e9101aa51441b4ef5