### PR TITLE
refactor: replace extraAlpineAttributes usage

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -23,8 +23,10 @@ class Money extends TextInput
         $this
             ->currency()
             ->prefix('R$')
-            ->extraAlpineAttributes(fn () => $this->getOnKeyPress())
-            ->extraAlpineAttributes(fn () => $this->getOnKeyUp())
+            ->alpineAttributes(fn () => array_merge(
+                $this->getOnKeyPress(),
+                $this->getOnKeyUp(),
+            ))
             ->formatStateUsing(fn ($state) => $this->hydrateCurrency($state))
             ->dehydrateStateUsing(fn ($state) => $this->dehydrateCurrency($state));
     }


### PR DESCRIPTION
## Summary
- replace deprecated `extraAlpineAttributes` with `alpineAttributes` in Money field
- merge Alpine event attributes to ensure masking JS still triggers

## Testing
- `composer format` *(fails: vendor/bin/pint not found)*
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb08c95d4c832e95a02347037834bc